### PR TITLE
Don't show dot files in directory listing

### DIFF
--- a/piratebox/piratebox/conf/lighttpd/lighttpd.conf
+++ b/piratebox/piratebox/conf/lighttpd/lighttpd.conf
@@ -33,6 +33,7 @@ static-file.exclude-extensions = ( ".php", ".pl", ".fcgi" , ".cgi" , ".py" )
 
 dir-listing.encoding        = "utf-8"
 server.dir-listing          = "enable"
+dir-listing.hide-dotfiles   = "enable"
 
 # Disabled, maybe fixes reload problem on imageboard
 #compress.cache-dir          = "/var/cache/lighttpd/compress/"


### PR DESCRIPTION
For OS X users who may put content in Shared by using the flash drive directly, this turns off the showing of hidden files in lighttpd.
