### PR TITLE
[fix] XSS in forest.py

### DIFF
--- a/piratebox/piratebox/src/forest.py
+++ b/piratebox/piratebox/src/forest.py
@@ -338,7 +338,7 @@ def new_subject(field_storage):
         raise ValueError( ERR_NO_SUBJECT )
     elif not body:
         raise ValueError( ERR_NO_BODY )
-    subject = subject.replace('\t', ' ')
+    subject = strip_html(subject.replace('\t', ' '))
     row_hash = update_thread( author, subject )
     new_post( author, subject, body, row_hash )
     return row_hash


### PR DESCRIPTION
Hey :)

The subject string in forest.py hasn't been escaped, which led to a persistent xss vulnerability. This should fix it :smiley: 

Oh and at the moment the name, subject and "body" are escaped before storing. I think it's better not to store it escaped, but rather display it escaped. Storing it escaped makes it harder to search through the forum posts.
Well, it isn't a big problem, but what do you think?
