### PR TITLE
Unified HTML-character-escaping

### DIFF
--- a/piratebox/piratebox/python_lib/psogen.py
+++ b/piratebox/piratebox/python_lib/psogen.py
@@ -21,6 +21,14 @@ except KeyError:
      broadcast_destination = False 
 
 
+def html_escape(text):
+    """Remove HTML chars from the given text and replace them with HTML
+entities. """
+    html_escape_table = {
+        '"': "&quot;", "'": "&apos;", ">": "&gt;",
+        "<": "&lt;"}
+    return "".join(html_escape_table.get(c,c) for c in text)
+
 #--------------
 #  Generates Shoutbox-HTML-Frame  ... 
 #           Imports:
@@ -91,27 +99,27 @@ def save_input( name , indata , color ):
         return writeToDisk ( content )
 
 def writeToNetwork ( content , broadcast_destination ):
-        message = messages.shoutbox_message()
-	message.set(content)
-        casting = broadcast.broadcast( )
-	casting.setDestination(broadcast_destination)
-	casting.set( message.get_message() )
-	casting.send()
-	return None
+    message = messages.shoutbox_message()
+    message.set(content)
+    casting = broadcast.broadcast( )
+    casting.setDestination(broadcast_destination)
+    casting.set( message.get_message() )
+    casting.send()
+    return None
 
 def writeToDisk ( content ):
-        old = read_data_file()
-        finalcontent = content  + old 
-        datafile = open(datafilename, 'r+')
-        datafile.write(finalcontent)
-        #datafile.truncate(0)
-        datafile.close()
-	return finalcontent 
+    old = read_data_file()
+    finalcontent = content  + old 
+    datafile = open(datafilename, 'r+')
+    datafile.write(finalcontent)
+    #datafile.truncate(0)
+    datafile.close()
+    return finalcontent 
 
-
-def prepare_line ( name, indata, color  ):
-    datapass = re.sub("<", "&lt;", indata)
-    data = re.sub(">", "&gt;", datapass)
+def prepare_line (name, indata, color):
+    name = html_escape(name)
+    data = html_escape(indata)
+    color = html_escape(color)
     curdate = datetime.datetime.now()
     # Trying to make it look like this: 
     # <div class="message">
@@ -132,6 +140,3 @@ if __name__ == "__main__":
   
   generate_html_from_file ()
   print "Generated HTML-Shoutbox File."
-
-
-

--- a/piratebox/piratebox/www/cgi-bin/psowrte.py
+++ b/piratebox/piratebox/www/cgi-bin/psowrte.py
@@ -4,26 +4,26 @@
 # Writes the recieved information to the data file.
 
 
-import cgi, datetime, os, re
+import cgi, datetime
 from  psogen import process_form 
+
 
 print "Content-type:text/html\r\n\r\n"
 
 values = cgi.FieldStorage()
 if values.has_key("name"):
-  name = values["name"].value
+  rawname = values["name"].value
 else:
-  name = "&nbsp;"
+  rawname = "&nbsp;"
 if values.has_key("data"):
   rawdata = values["data"].value
 else:
   rawdata = "&nbsp;"
-datapass = re.sub("<", "&lt;", rawdata)
-data = re.sub(">", "&gt;", datapass)
+
 color = values["color"].value
 curdate = datetime.datetime.now()
 
-process_form( name , rawdata , color )
+process_form(rawname, rawdata, color)
 
 print """<html><body>ok</body></html>"""
 


### PR DESCRIPTION
It used to escape the data twice, once in psowrte and once in psogen.
Now, the whole escaping for the ShoutBox is now done in psogen.py

-> same as #79, but for hotfix1.0.2

Plus: We forgot to escape color, it's also fixed.

Conflicts:
    piratebox/piratebox/python_lib/psogen.py
    piratebox/piratebox/www/cgi-bin/psowrte.py
