### PR TITLE
Bugfix: the scritp "distribute_file_into_directory.dh" is now working even when the path contain spaces.

### DIFF
--- a/piratebox/piratebox/bin/distribute_file_into_directory.sh
+++ b/piratebox/piratebox/bin/distribute_file_into_directory.sh
@@ -18,10 +18,10 @@ filename="${src_file##*/}"
  $DEBUG && echo "filename: $filename"
  $DEBUG && echo "Overwrite mode : $overwrite "
 
-if [ ! -e $directory/$filename ] || [ "$overwrite" = true ] ; then
+if [ ! -e "$directory/$filename" ] || [ "$overwrite" = true ] ; then
 	echo "Distribute $filename into $directory "
  	$DEBUG && echo "	cp $src_file $directory "
-	$TEST_RUN ||  cp $src_file $directory  
+	$TEST_RUN ||  cp "$src_file" "$directory"  
 else
 	$DEBUG && echo "File exists"
 fi


### PR DESCRIPTION
The script is not working if a directory has a space in it because of the missing " " around the path variable.
