### PR TITLE
Fake a full internet connection for android devices

### DIFF
--- a/piratebox/piratebox/conf/lighttpd/fastcgi.conf
+++ b/piratebox/piratebox/conf/lighttpd/fastcgi.conf
@@ -9,3 +9,17 @@ fastcgi.server = (
                 ))
 )
 
+# Run a specific php script when the URL /generate_204 is requested.
+# Android clients request this URL to check for a full working
+# internet connection, we want to fake a reply. This config section is
+# a hack to make a php script without the ".php" extension work when
+# mod_rewrite is not available.
+$HTTP["url"] =~ "^/generate_204$" {
+        fastcgi.server = (
+                "" => ((
+                                "bin-path" => "/usr/bin/php-cgi",
+                                "socket" => "/tmp/php.socket",
+                                "max-procs" => 1
+                        ))
+        )
+}

--- a/piratebox/piratebox/www/generate_204.php
+++ b/piratebox/piratebox/www/generate_204.php
@@ -1,0 +1,5 @@
+<?php
+// Return an empty page to fake a working internet connection for
+// android
+http_response_code(204);
+?>


### PR DESCRIPTION
This uses a rather ugly hack to enable serving an extension-less php
file, but I couldn't find a better way to do this in the absence of
mod_rewrite.

Tested manually that it works on two different android devices (5.1.1).

Closes #59