### PR TITLE
Fixed accidental redirects

### DIFF
--- a/piratebox/piratebox/www/redirect.html
+++ b/piratebox/piratebox/www/redirect.html
@@ -1,7 +1,9 @@
 <html>
 <head><title>Redirect...</title>
 <meta http-equiv="refresh" content="0;url=http://piratebox.lan/" />
-<meta http-equiv='cache-control' content='no-cache'>
+<meta http-equiv='cache-control' content='no-cache, no-store, must-revalidate' />
+<meta http-equiv='pragma' content='no-cache' />
+<meta http-equiv='expires' content='0' />
 </head>
 <body>
 Redirect


### PR DESCRIPTION
Sometimes a user would still be redirected to a cached piratebox.lan site after disconnecting from the piratebox wifi. This has something to do with how different browsers interact with the cache-control meta tag. Adding "pragma" and "expires" tags as well as additional "cache-control" contents fixes that.