### PR TITLE
Fix #! in rpi_hwclock script

### DIFF
--- a/piratebox/piratebox/bin/rpi_hwclock.sh
+++ b/piratebox/piratebox/bin/rpi_hwclock.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 # This small shell script initializes the I2C bus on a Raspberry Pi
 # and activates an installed real time clock module. 
 # Afterwards the system time is synced to the hardware clock.


### PR DESCRIPTION
As MatStr discovered, #! was having an addiotional space behind it, it's now removed.