### PR TITLE
Droopy: block index.php uploads

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,6 +22,7 @@ Contributors for modifications:
        # herr-gabriel
        # Jess Stubenbord
        # Mike Weaver
+       # casdr
        # ... and all others I might have forgotten.
 
 

--- a/piratebox/piratebox/bin/droopy
+++ b/piratebox/piratebox/bin/droopy
@@ -6,6 +6,7 @@
 # Licensed under the New BSD License.
 
 # Changelog
+#   20160417 * Block index.php uploads
 #   20131121 * Update HTML/CSS for mobile devices
 #            * Add HTTPS support
 #            * Add HTTP basic authentication
@@ -836,7 +837,7 @@ class HTTPUploadHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                     continue
 
 
-                if filename.lower() == "index.html" or filename.lower() == "index.htm":
+                if filename.lower() == "index.html" or filename.lower() == "index.htm" or filename.lower() == "index.php":
                     self.send_response(303)
                     self.send_header('Location', '/')
                     self.end_headers()


### PR DESCRIPTION
When index.php is uploaded, the directory listing doesn't works anymore and you get redirected to the home of PirateBox' web interface. This blocks index.php uploads through droopy.