### PR TITLE
Fixed localization ID for placeholder message.

### DIFF
--- a/piratebox/piratebox/www_content/index.html
+++ b/piratebox/piratebox/www_content/index.html
@@ -69,7 +69,7 @@
 				<form method="POST" name="psowrte" id="sb_form" onsubmit='getTime();'>
 					<div id="shoutbox-input">
 						<input class="nickname" type="text" 	name="name" 	value="Anonymous" placeholder="Nickname" data-l10n-id="mainChatName" >
-						<input class="message" 	type="text" 	name="data" 	placeholder="Message..." data-l10n-id="mainChatMessage.placeholder" >
+						<input class="message" 	type="text" 	name="data" 	placeholder="Message..." data-l10n-id="mainChatMessage" >
 						<input class="button" 	type="submit" 	name="submit" 	value="Send"  id="send-button" data-l10n-id="mainChatSend" >
 					</div>
 					<div id="shoutbox-options">


### PR DESCRIPTION
`data-l10n-id` for `<input class="message">` has to be `"mainChatMessage"` instead of `"mainChatMessage.placeholder"`, otherwise translations wouldn't show up.