### PR TITLE
Fix /tmp/ folder empty

### DIFF
--- a/piratebox/piratebox/init.d/piratebox
+++ b/piratebox/piratebox/init.d/piratebox
@@ -91,7 +91,7 @@ case "$1" in
     $PIRATEBOX/bin/hooks/hook_piratebox_start.sh  "$CONF"
 
     echo "Empty tmp folder"
-    find   $PIRATEBOX/tmp/  -exec rm {} \;
+    find   $PIRATEBOX/tmp/*  -exec rm {} \;
 
     if [ "$CUSTOM_DIRLIST_COPY" = "yes" ]; then
        echo "Copy over directory design files"


### PR DESCRIPTION
-----
## Issue
```/opt/piratebox/tmp/``` folder is not emptied properly during installation.

## Expected result
no errors empyting ```/opt/piratebox/tmp/``` folder.

## Error Thrown
```
rm: cannot remove '/opt/piratebox/tmp/': Is a directory
```

## Reproduction  
```sudo ./install.sh```


## Suggested Fix
Change ln94 of  ```piratebox/init.d/piratebox```  

from: ```find   $PIRATEBOX/tmp/  -exec rm {} \;```  
to: ```find   $PIRATEBOX/tmp/*  -exec rm {} \;```

## Results after Suggested Fix
no errors emptying ```/opt/piratebox/tmp/``` folder.  

-----